### PR TITLE
fix: markdown content's scrollbar

### DIFF
--- a/devui-blue.scss
+++ b/devui-blue.scss
@@ -27,7 +27,6 @@ $devui-border-radius: 2px;
   line-height: 1.75;
   font-weight: 400;
   font-size: 16px;
-  overflow-x: hidden;
   color: $devui-text;
 
   h1,


### PR DESCRIPTION
![image](https://github.com/kagol/juejin-markdown-theme-devui-blue/assets/50617660/05227f0b-3950-4886-b82e-0c29b49e138c)
